### PR TITLE
Update README.md to correct on: schedule cron syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ When executing, this action:
 ```yaml
 name: Automatic Approve
 on:
-  schedule: "*/5 * * * *"
+  schedule: 
+    - cron:  "*/5 * * * *"
 jobs:
   automatic-approve:
     name: Automatic Approve


### PR DESCRIPTION
I got an error trying this out due to incorrect ` on: schedule` syntax. 

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
```yaml
on:
  schedule: 
    - cron:  "*/5 * * * *"
```