### PR TITLE
Fix named workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ When executing, this action:
 ```yaml
 name: Automatic Approve
 on:
-  schedule: 
-    - cron:  "*/5 * * * *"
+  schedule:
+    - cron: "*/5 * * * *"
 jobs:
   automatic-approve:
     name: Automatic Approve
@@ -30,6 +30,8 @@ jobs:
           workflows: "pr.yml,lint.yml"
           dangerous_files: "build.js"
 ```
+
+> **Important**: If you have multiple workflows with the same `name` and one of them is in the `workflows` list, **all** of the workflows with that name will be approved
 
 ## Available Configuration
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const core = require("@actions/core");
 const github = require("@actions/github");
+const yaml = require("js-yaml");
 
 async function action() {
   const owner = github.context.repo.owner;
@@ -19,6 +20,21 @@ async function action() {
     .filter((r) => r);
   dangerousFiles.push(".github/workflows");
 
+  // Load the provided workflows so that we can map the workflow
+  // name (available in the runs API) to the workflow file
+  const nameToWorkflow = {};
+  for (let w of allowedWorkflows) {
+    const { data: file } = await octokit.repos.getContent({
+      owner,
+      repo,
+      path: w,
+    });
+    const workflow = yaml.load(Buffer.from(file.content, "base64"));
+    if (workflow.name) {
+      nameToWorkflow[workflow.name] = w;
+    }
+  }
+
   // Fetch runs that require action
   let { data: runs } = await octokit.actions.listWorkflowRunsForRepo({
     owner,
@@ -33,9 +49,15 @@ async function action() {
   }
 
   // Filter only to workflows that are in the allow list
-  runs = runs.workflow_runs.filter((run) =>
-    allowedWorkflows.includes(run.name)
-  );
+  runs = runs.workflow_runs.filter((run) => {
+    let name;
+    if (nameToWorkflow[run.name]) {
+      name = nameToWorkflow[run.name];
+    } else {
+      name = run.name;
+    }
+    return allowedWorkflows.includes(name);
+  });
 
   if (runs.length == 0) {
     console.log(
@@ -43,6 +65,7 @@ async function action() {
         ", "
       )}`
     );
+    return;
   }
 
   // Remove any PRs that edit the `.github/workflows` directory
@@ -53,6 +76,13 @@ async function action() {
       repo,
       head: `${run.head_repository.owner.login}:${run.head_branch}`,
     });
+
+    if (pulls.length === 0) {
+      console.log(
+        `No run found for '${run.head_repository.owner.login}:${run.head_branch}'`
+      );
+      return acc;
+    }
 
     // List all the files in there
     const { data: files } = await octokit.rest.pulls.listFiles({

--- a/index.js
+++ b/index.js
@@ -20,6 +20,19 @@ async function action() {
     .filter((r) => r);
   dangerousFiles.push(".github/workflows");
 
+  // Fetch runs that require action
+  let { data: runs } = await octokit.actions.listWorkflowRunsForRepo({
+    owner,
+    repo,
+    status: "action_required",
+  });
+
+  // If there are no runs, return early
+  if (runs.total_count == 0) {
+    console.log("No runs found with status 'action_required'");
+    return;
+  }
+
   // Load the provided workflows so that we can map the workflow
   // name (available in the runs API) to the workflow file
   const nameToWorkflow = {};
@@ -33,19 +46,6 @@ async function action() {
     if (workflow.name) {
       nameToWorkflow[workflow.name] = w;
     }
-  }
-
-  // Fetch runs that require action
-  let { data: runs } = await octokit.actions.listWorkflowRunsForRepo({
-    owner,
-    repo,
-    status: "action_required",
-  });
-
-  // If there are no runs, return early
-  if (runs.total_count == 0) {
-    console.log("No runs found with status 'action_required'");
-    return;
   }
 
   // Filter only to workflows that are in the allow list

--- a/index.test.js
+++ b/index.test.js
@@ -1,5 +1,6 @@
 const core = require("@actions/core");
 const action = require("./index");
+const yaml = require("js-yaml");
 
 const nock = require("nock");
 nock.disableNetConnect();
@@ -145,10 +146,13 @@ it("removes any runs that edit a file in dangerous_files", async () => {
   expect(console.log).toBeCalledWith("Skipped dangerous run '12345678'");
 });
 
-it("approves all pending workflows", async () => {
+it("approves all pending workflows (no name)", async () => {
   mockInputToken();
   mockInputWorkflows();
   jest.spyOn(console, "log").mockImplementation(() => {});
+
+  mockWorkflowContents("pr.yml", {});
+  mockWorkflowContents("another.yml", {});
 
   nock("https://api.github.com")
     .get("/repos/demo/repo/actions/runs?status=action_required")
@@ -167,6 +171,56 @@ it("approves all pending workflows", async () => {
         },
         {
           name: ".github/workflows/pr.yml",
+          id: "87654321",
+          head_branch: "update-readme",
+          head_repository: {
+            owner: {
+              login: "user-b",
+            },
+          },
+        },
+      ],
+    });
+
+  mockGetPr("user-a%3Apatch-1", 99);
+  mockGetPr("user-b%3Aupdate-readme", 42);
+
+  mockPrFiles(99, ["README.md"]);
+  mockPrFiles(42, ["README.md"]);
+
+  mockApprove(12345678);
+  mockApprove(87654321);
+
+  await action();
+  expect(console.log).toBeCalledWith("Approved run '12345678'");
+  expect(console.log).toBeCalledWith("Approved run '87654321'");
+});
+
+it("approves all pending workflows (with name)", async () => {
+  mockInputToken();
+  mockInputWorkflows();
+  jest.spyOn(console, "log").mockImplementation(() => {});
+
+  mockWorkflowContents("pr.yml", { name: "Run Tests" });
+  mockWorkflowContents("another.yml", { name: "Do Another Thing" });
+
+  nock("https://api.github.com")
+    .get("/repos/demo/repo/actions/runs?status=action_required")
+    .reply(200, {
+      total_count: 2,
+      workflow_runs: [
+        {
+          name: "Run Tests",
+          id: "12345678",
+          head_branch: "patch-1",
+          head_repository: {
+            owner: {
+              login: "user-a",
+            },
+          },
+        },
+        {
+          name: "Do Another Thing",
           id: "87654321",
           head_branch: "update-readme",
           head_repository: {
@@ -232,4 +286,17 @@ function mockApprove(run) {
   nock("https://api.github.com")
     .post(`/repos/demo/repo/actions/runs/${run}/approve`)
     .reply(200);
+}
+
+function mockWorkflowContents(name, content) {
+  content = {
+    on: "push",
+    jobs: [],
+    ...content,
+  };
+  nock("https://api.github.com")
+    .get(`/repos/demo/repo/contents/.github%2Fworkflows%2F${name}`)
+    .reply(200, {
+      content: Buffer.from(yaml.dump(content)).toString("base64"),
+    });
 }

--- a/index.test.js
+++ b/index.test.js
@@ -48,6 +48,9 @@ it("returns early if there are no runs with action required", async () => {
 it("returns early if there are no runs that match the provided workflow", async () => {
   mockInputToken();
   mockInputWorkflows();
+  mockWorkflowContents("pr.yml", {});
+  mockWorkflowContents("another.yml", {});
+
   jest.spyOn(console, "log").mockImplementation(() => {});
 
   nock("https://api.github.com")
@@ -71,6 +74,8 @@ it("returns early if there are no runs that match the provided workflow", async 
 it("removes any runs that edit .github/workflows", async () => {
   mockInputToken();
   mockInputWorkflows();
+  mockWorkflowContents("pr.yml", {});
+  mockWorkflowContents("another.yml", {});
   jest.spyOn(console, "log").mockImplementation(() => {});
 
   nock("https://api.github.com")
@@ -118,6 +123,8 @@ it("removes any runs that edit a file in dangerous_files", async () => {
   mockInputToken();
   mockInputWorkflows();
   mockInputDangerousFiles("build.js");
+  mockWorkflowContents("pr.yml", {});
+  mockWorkflowContents("another.yml", {});
   jest.spyOn(console, "log").mockImplementation(() => {});
 
   nock("https://api.github.com")

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.7",
-        "@actions/github": "^4.0.0"
+        "@actions/github": "^4.0.0",
+        "js-yaml": "^3.14.1"
       },
       "devDependencies": {
         "jest": "^26.0.1",
@@ -1043,7 +1044,6 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -1856,7 +1856,6 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -3314,7 +3313,6 @@
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -5047,7 +5045,6 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
@@ -6572,7 +6569,6 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -7113,8 +7109,7 @@
       }
     },
     "esprima": {
-      "version": "4.0.1",
-      "dev": true
+      "version": "4.0.1"
     },
     "estraverse": {
       "version": "5.2.0",
@@ -8100,7 +8095,6 @@
     },
     "js-yaml": {
       "version": "3.14.1",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -9266,8 +9260,7 @@
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "@actions/core": "^1.2.7",
-    "@actions/github": "^4.0.0"
+    "@actions/github": "^4.0.0",
+    "js-yaml": "^3.14.1"
   },
   "devDependencies": {
     "jest": "^26.0.1",


### PR DESCRIPTION
When using a named workflow `run.name` contains the provided string rather than the workflow path. This causes the workflow approval to be skipped.

This PR adds support for named workflows by building a map of workflow name=>filename pairs and using that to check if a workflow should be approved later.

Resolves #5 
