### PR TITLE
Update action to node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [20.x, 22.x]
 
     env:
       CI: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 # You can specify a version:
 # FROM node:10-slim
-FROM node:slim
+FROM node:20-slim
 
 # Labels for GitHub to read your action
 LABEL "com.github.actions.name"="Automatic Approve"

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Automatic Approve
 description: Automatically approve workflow runs from first time contributors
 runs:
-  using: node12
+  using: node20
   main: index.js
 branding:
   icon: user-check


### PR DESCRIPTION
Part of [QMK Firmware](https://qmk.fm/) updates to better handle our current use cases https://github.com/zvecr/automatic-approve-action/pull/1.

Action currently produces warnings due to <https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/>.