### PR TITLE
Implement 'safe_files'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ jobs:
 | `token`           | The GitHub Token to use. Must be a [personal access token](https://github.com/settings/tokens) with the `repo` scope | true     | N/A     |
 | `workflows`       | The workflows to automatically approve                                                                               | true     | N/A     |
 | `dangerous_files` | A comma-separated list of filenames that prevent the PR being automatically approved                                 | false    |         |
+| `safe_files` | A comma-separated list of filenames that allow the PR being automatically approved                                 | false    |         |

--- a/action.yml
+++ b/action.yml
@@ -16,4 +16,6 @@ inputs:
   dangerous_files:
     description: Filenames that prevent the PR being automatically approved
     required: false
-
+  safe_files:
+    description: Filenames that allow the PR being automatically approved
+    required: false


### PR DESCRIPTION
Part of [QMK Firmware](https://qmk.fm/) updates to better handle our current use cases https://github.com/zvecr/automatic-approve-action/pull/1.

Closes #11.

With the [qmk_firmware repo](https://github.com/qmk/qmk_firmware) having a mixture of "core" and what could be considered "user code", wild carding the "dangerous files" can be quite verbose and error prone.

While fixing the [node20 warnings](https://github.com/mheap/automatic-approve-action/pull/20), the safe_files issue was noted as a cleaner way to handle our CI needs.